### PR TITLE
Make Apple-specific exception classes public

### DIFF
--- a/Exceptions/AppleRequestException.cs
+++ b/Exceptions/AppleRequestException.cs
@@ -5,7 +5,7 @@ namespace AppleAuth.Exceptions
     /// <summary>
     /// Encapsulates error response from Apple's REST API
     /// </summary>
-    internal class AppleRequestException: Exception
+    public class AppleRequestException: Exception
     {
         internal AppleRequestException(string message) : base(message)
         {

--- a/Exceptions/InvalidParametersException.cs
+++ b/Exceptions/InvalidParametersException.cs
@@ -5,7 +5,7 @@ namespace AppleAuth.Exceptions
     /// <summary>
     /// Thrown when one or more parameters is null or invalid.
     /// </summary>
-    internal class InvalidParametersException : Exception
+    public class InvalidParametersException : Exception
     {
         internal InvalidParametersException(string message) : base(message) { }
     }


### PR DESCRIPTION
Making the Apple-specific exception classes public allows user code to differentiate between these and other general exceptions, rather than trying to analyze the contents of all exceptions in order to figure out which ones were thrown from the AppleAuth library.