### PR TITLE
Added BaseUri to AppleAuthProvider with the default value

### DIFF
--- a/Constants/GlobalConstants.cs
+++ b/Constants/GlobalConstants.cs
@@ -5,9 +5,11 @@
     /// </summary>
     internal static class GlobalConstants
     {
-        internal const string AppleAuthorizeTokenURL = "https://appleid.apple.com/auth/token";
-        internal const string AppleAuthorizeURL = "https://appleid.apple.com/auth/authorize";
-        internal const string AppleAuthorizeRevokeURL = "https://appleid.apple.com/auth/revoke";
+        internal const string BaseUri = "https://appleid.apple.com";
+        internal const string AppleAuthorizeTokenURL = "/auth/token";
+        internal const string AppleAuthorizeURL = "/auth/authorize";
+        internal const string AppleAuthorizeRevokeURL = "/auth/revoke";
+        internal const string ApplePublicKeysURL = "/auth/keys";
         internal static readonly string[] NewLineSeparators = { "\r", "\n", "\r\n" };
     }
 }

--- a/Http/AppleRestClient.cs
+++ b/Http/AppleRestClient.cs
@@ -1,4 +1,5 @@
-﻿using AppleAuth.Constants;
+﻿using System;
+using AppleAuth.Constants;
 using AppleAuth.Exceptions;
 using AppleAuth.TokenObjects;
 using System.Collections.Generic;
@@ -36,7 +37,7 @@ namespace AppleAuth.Http
         /// <summary>
         /// Generates an HttpRequestMessage as described in Apple's documentation: https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens
         /// </summary>
-        internal HttpRequestMessage GenerateRequestMessage(string tokenType, string authorizationCode, string clientSecret, string clientId, string redirectUrl)
+        internal HttpRequestMessage GenerateRequestMessage(string tokenType, string authorizationCode, string clientSecret, string clientId, string redirectUrl, Uri baseUri)
         {
             var bodyAsPairs = new List<KeyValuePair<string, string>>()
             {
@@ -55,13 +56,13 @@ namespace AppleAuth.Http
 
             content.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
 
-            return new HttpRequestMessage(HttpMethod.Post, GlobalConstants.AppleAuthorizeTokenURL) { Content = content };
+            return new HttpRequestMessage(HttpMethod.Post, new Uri(baseUri, GlobalConstants.AppleAuthorizeTokenURL)) { Content = content };
         }
 
         /// <summary>
         /// Generates an HttpRequestMessage for token revoke as described in Apple's documentation: https://developer.apple.com/documentation/sign_in_with_apple/revoke_tokens
         /// </summary>
-        internal HttpRequestMessage GenerateRevokeMessage(string token, string clientSecret, string clientId, string tokenType)
+        internal HttpRequestMessage GenerateRevokeMessage(string token, string clientSecret, string clientId, string tokenType, Uri baseUri)
         {
             var bodyAsPairs = new List<KeyValuePair<string, string>>()
             {
@@ -80,7 +81,7 @@ namespace AppleAuth.Http
 
             content.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
 
-            return new HttpRequestMessage(HttpMethod.Post, GlobalConstants.AppleAuthorizeRevokeURL) { Content = content };
+            return new HttpRequestMessage(HttpMethod.Post, new Uri(baseUri, GlobalConstants.AppleAuthorizeRevokeURL)) { Content = content };
         }
     }
 }


### PR DESCRIPTION
PR is related to https://github.com/Accedia/appleauth-net/issues/34 issue.

This is a possible solution to pass your `BaseUri` for API test purposes.